### PR TITLE
Update link to raw js.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -4,7 +4,7 @@ QUnit Mock provides some mock assertions and stubs for QUnit.
 
 h2. Installation
 
-Just download the "qunit.mock.js":http://github.com/bitzesty/qunit-mock/raw/master/lib/qunit.mock.js and include it after @QUnit@.
+Just download the "qunit.mock.js":https://github.com/dlangevin/qunit-mock/raw/refs/heads/master/lib/qunit.mock.js and include it after @QUnit@.
 
 h2. Expecting calls
 


### PR DESCRIPTION
Updated the README. It still linked to the old bitzesty address, which 404s.